### PR TITLE
Correção no link da documentação no ReadTheDocs que estava quebrado

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### A documentação pode ser visualizada online no [ReadTheDocs](https://julia_pt-br.readthedocs.org/en/latest/)!
+### A documentação pode ser visualizada online no [ReadTheDocs](http://julia-pt-br.readthedocs.io)!
 
 README da tradução brasileira
 =============================
@@ -8,7 +8,7 @@ Contribuindo
 
 Contribuições são sempre bem-vindas, e podem ser feitas das seguintes maneiras,
 em ordem de praticidade:
-- Enviar um pull request diretamente aqui no GitHub. Isto pode ser feito 
+- Enviar um pull request diretamente aqui no GitHub. Isto pode ser feito
   automaticamente se você possuir uma conta no site, basta editar um arquivo
   e enviar.
 - Enviar um patch via diff ou git por e-mail em alessandroandrioni@gmail.com
@@ -23,7 +23,7 @@ mantê-las para garantir um projeto fácil de ser cuidado e atualizado!
 
 Linhas devem preferencialmente ter 71 caracteres ou menos, para facilitar
 a edição do texto nos mais variados programas e celulares/tablets. Se duas
-linhas estão em sequência, elas vão ser unidas no mesmo parágrafo 
+linhas estão em sequência, elas vão ser unidas no mesmo parágrafo
 automaticamente na documentação final.
 
 Termos em língua estrangeira devem estar em itálico.
@@ -56,7 +56,7 @@ possuem tradução para o português.
 README da Documentação de Julia
 ===============================
 
-A documentação de Julia está escrita em reStructuredText, e uma boa referência 
+A documentação de Julia está escrita em reStructuredText, e uma boa referência
 é o capítulo [Documenting Python](http://docs.python.org/devguide/documenting.html)
 do Python Developer's Guide.
 


### PR DESCRIPTION
Alteração do link da versão brasileira:

De: https://julia_pt-br.readthedocs.org/en/latest/

Para: http://julia-pt-br.readthedocs.io